### PR TITLE
Move to .NET Standard 2.0

### DIFF
--- a/ClassicBasic.Interpreter/ClassicBasic.Interpreter.csproj
+++ b/ClassicBasic.Interpreter/ClassicBasic.Interpreter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>Full</DebugType>
     <AssemblyName>ClassicBasic.Interpreter</AssemblyName>
     <RootNamespace>ClassicBasic.Interpreter</RootNamespace>

--- a/ClassicBasic.Interpreter/VariableRepository.cs
+++ b/ClassicBasic.Interpreter/VariableRepository.cs
@@ -83,7 +83,7 @@ namespace ClassicBasic.Interpreter
             if (name.Length > 2)
             {
                 nameKey = name.Substring(0, 2);
-                var lastChar = name[^1];
+                var lastChar = name[name.Length - 1];
                 if ((lastChar == '$') || (lastChar == '%'))
                 {
                     nameKey += lastChar;


### PR DESCRIPTION
This change sets the interpreter library to .NET Standard 2.0. There is no reason why you would need to target .NET Core on the library. With .NET Standard 2.0 (not 2.1) you can use the library from .NET Framework, Mono, and .NET Core.

This however means that the C# 8.0 features aren't available. You only had once instance where you were using a C# 8.0 feature.

You would be able to use C# 8.0 in the sample application, which continues to target .NET Core 3.1.

>**NOTE**\
>The documentation paths you have in the project files prevent anyone but yourself from compiling, as the target folder doesn't exist on my machine.