### PR TITLE
Fix print statement regarding tokens

### DIFF
--- a/ClassicBasic.Interpreter/ProgramLine.cs
+++ b/ClassicBasic.Interpreter/ProgramLine.cs
@@ -112,9 +112,10 @@ namespace ClassicBasic.Interpreter
         {
             var line = new StringBuilder();
             line.Append($"{LineNumber} ");
-            while (!EndOfLine)
+
+            foreach (var item in _tokens)
             {
-                line.Append(NextToken().ToString());
+                line.Append(item.ToString());
             }
 
             return line.ToString();


### PR DESCRIPTION
The current `ProgramLine.ToString` method ends up calling `NextToken()` which moves the token pointer. This makes it impossible to debug in visual studio. if you hover over the `ProgramLine` it calls the `ToString` method and then messes up the interpreter. This change just cycles all the tokens without moving the pointer.